### PR TITLE
added functionality to login with QR mnemonic and a step for adding Saifu Account functionality

### DIFF
--- a/src/lib/screens/login_screen.dart
+++ b/src/lib/screens/login_screen.dart
@@ -3,12 +3,15 @@ import 'dart:html' as html;
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:flutter/material.dart';
+
 import 'package:kira_auth/utils/export.dart';
+
 import 'package:kira_auth/widgets/export.dart';
 import 'package:kira_auth/models/export.dart';
 import 'package:kira_auth/blocs/export.dart';
 import 'package:kira_auth/services/export.dart';
 import 'package:kira_auth/service_manager.dart';
+import 'package:kira_auth/widgets/qrcode_scanner_dialog.dart';
 
 class LoginScreen extends StatefulWidget {
   @override
@@ -16,10 +19,12 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
+  int i = 1;
   List<String> networkIds = [Strings.customNetwork];
   String networkId = Strings.customNetwork;
   String testedRpcUrl = "";
   bool isLoading = false, isHover = false, isNetworkHealthy = false, isRpcError = false;
+  bool saifuQR = false;
 
   HeaderWrapper headerWrapper;
   FocusNode rpcUrlNode;
@@ -133,10 +138,13 @@ class _LoginScreenState extends State<LoginScreen> {
                     children: <Widget>[
                       addHeaderTitle(),
                       if (isNetworkHealthy == false) addNetworks(context),
-                      if (isNetworkHealthy == false && networkId == Strings.customNetwork) addCustomRPC(),
+                      if (isNetworkHealthy == false && networkId == Strings.customNetwork)
+                        addCustomRPC(),
                       if (isLoading == true) addLoadingIndicator(),
                       // addErrorMessage(),
-                      if (networkId == Strings.customNetwork && isNetworkHealthy == false && isLoading == false)
+                      if (networkId == Strings.customNetwork &&
+                          isNetworkHealthy == false &&
+                          isLoading == false)
                         addConnectButton(context),
                       isNetworkHealthy == true && isLoading == false
                           ? Column(
@@ -175,20 +183,25 @@ class _LoginScreenState extends State<LoginScreen> {
                 Text(
                   "Node with address " + testedRpcUrl + " could not be reached",
                   textAlign: TextAlign.left,
-                  style: TextStyle(color: KiraColors.danger, fontSize: 20, fontWeight: FontWeight.w900),
+                  style: TextStyle(
+                      color: KiraColors.danger, fontSize: 20, fontWeight: FontWeight.w900),
                 ),
               SizedBox(height: 20),
               Text(
                 connected ? Strings.selectLoginOption : Strings.selectFullNode,
                 textAlign: TextAlign.left,
-                style: TextStyle(color: KiraColors.green3, fontSize: 20, fontWeight: FontWeight.w900),
+                style:
+                    TextStyle(color: KiraColors.green3, fontSize: 20, fontWeight: FontWeight.w900),
               ),
               if (!connected) SizedBox(height: 15),
               if (!connected)
                 Text(
                   Strings.requireSSL,
                   textAlign: TextAlign.left,
-                  style: TextStyle(color: KiraColors.white.withOpacity(0.6), fontSize: 15, fontWeight: FontWeight.w300),
+                  style: TextStyle(
+                      color: KiraColors.white.withOpacity(0.6),
+                      fontSize: 15,
+                      fontWeight: FontWeight.w300),
                 )
             ]));
   }
@@ -209,7 +222,8 @@ class _LoginScreenState extends State<LoginScreen> {
               children: [
                 Container(
                   padding: EdgeInsets.only(top: 10, left: 15, bottom: 0),
-                  child: Text(Strings.availableNetworks, style: TextStyle(color: KiraColors.kGrayColor, fontSize: 12)),
+                  child: Text(Strings.availableNetworks,
+                      style: TextStyle(color: KiraColors.kGrayColor, fontSize: 12)),
                 ),
                 ButtonTheme(
                   alignedDropdown: true,
@@ -237,7 +251,8 @@ class _LoginScreenState extends State<LoginScreen> {
                           child: Container(
                               height: 25,
                               alignment: Alignment.topCenter,
-                              child: Text(value, style: TextStyle(color: KiraColors.white, fontSize: 18))),
+                              child: Text(value,
+                                  style: TextStyle(color: KiraColors.white, fontSize: 18))),
                         );
                       }).toList()),
                 ),
@@ -322,19 +337,63 @@ class _LoginScreenState extends State<LoginScreen> {
   }
 
   Widget addLoginWithKeyFileButton(isBigScreen) {
-    return CustomButton(
-      key: Key(Strings.loginWithKeyFile),
-      text: Strings.loginWithKeyFile,
-      width: isBigScreen ? 220 : null,
-      height: 60,
-      style: 2,
-      onPressed: () {
-        String customInterxRPCUrl = rpcUrlController.text;
-        if (customInterxRPCUrl.length > 0) {
-          _storageService.setInterxRPCUrl(customInterxRPCUrl);
-        }
-        Navigator.pushReplacementNamed(context, '/login-keyfile');
-      },
+    return Stack(
+      children: [
+        CustomButton(
+          key: Key(Strings.loginWithKeyFile),
+          text: Strings.loginWithKeyFile,
+          width: isBigScreen ? 220 : null,
+          height: 60,
+          style: 2,
+          onPressed: () {
+            String customInterxRPCUrl = rpcUrlController.text;
+            if (customInterxRPCUrl.length > 0) {
+              _storageService.setInterxRPCUrl(customInterxRPCUrl);
+            }
+            Navigator.pushReplacementNamed(context, '/login-keyfile');
+          },
+        ),
+        if (saifuQR == true)
+          Positioned(
+            top: 0,
+            right: 0,
+            child: ClipRRect(
+                borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(50),
+                    bottomLeft: Radius.circular(50),
+                    bottomRight: Radius.circular(50)),
+                child: Container(
+                  color: Color.fromRGBO(31, 23, 76, 1),
+                  child: IconButton(
+                    icon: Icon(
+                      Icons.qr_code,
+                      color: Colors.white,
+                      size: 20,
+                    ),
+                    onPressed: () {
+                      showDialog(
+                          context: context,
+                          barrierColor: Colors.black54,
+                          builder: (BuildContext context) {
+                            return QrScannerDialog(
+                              title: "Login in with Saifu",
+                              qrCodeFunction: () => {
+                                //TODO: Implement SAIFU Accounts (Explorer Account (public address)  with Saifu Signer on Withdrawing)
+
+                                Navigator.popUntil(
+                                  context,
+                                  ModalRoute.withName(
+                                    '/login',
+                                  ),
+                                )
+                              },
+                            );
+                          });
+                    },
+                  ),
+                )),
+          )
+      ],
     );
   }
 

--- a/src/lib/widgets/qrcode_scanner_dialog.dart
+++ b/src/lib/widgets/qrcode_scanner_dialog.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:kira_auth/webcam/qr_code_scanner_web.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class QrScannerDialog extends StatefulWidget {
+  String title;
+  Function qrCodeFunction;
+
+  QrScannerDialog({this.title, this.qrCodeFunction});
+  @override
+  QrScannerDialogState createState() => QrScannerDialogState();
+}
+
+class QrScannerDialogState extends State<QrScannerDialog> {
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+        elevation: 0.0,
+        backgroundColor: Colors.transparent,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
+        content: Container(
+            width: 350,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(10),
+                  child: Container(
+                    color: Color.fromRGBO(0, 26, 69, 1),
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 20),
+                      child: Column(
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.all(10.0),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  widget.title,
+                                  style: TextStyle(color: Colors.white),
+                                ),
+                              ],
+                            ),
+                          ),
+                          Container(
+                            color: Colors.white,
+                            child: SizedBox(
+                              width: 350,
+                              child:
+                                  Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+                                Column(
+                                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                                  children: [],
+                                ),
+                                Padding(
+                                  padding: const EdgeInsets.all(30),
+                                  child: ConstrainedBox(
+                                    constraints: BoxConstraints(maxHeight: 350),
+                                    child: QrCodeCameraWeb(
+                                      fit: BoxFit.cover,
+                                      qrCodeCallback: (scanData) async {
+                                        if (mounted) {
+                                          widget.qrCodeFunction();
+                                        }
+                                      },
+                                    ),
+                                  ),
+                                ),
+                                Column(crossAxisAlignment: CrossAxisAlignment.center, children: [
+                                  Padding(
+                                    padding: const EdgeInsets.all(20),
+                                    child: Column(
+                                      children: [
+                                        Text(
+                                          "Don't have Saifu wallet app?",
+                                          textAlign: TextAlign.center,
+                                          style: TextStyle(fontWeight: FontWeight.bold),
+                                        ),
+                                        Container(
+                                          height: 75,
+                                          width: 200,
+                                          padding: EdgeInsets.all(0),
+                                          decoration: BoxDecoration(
+                                            image: DecorationImage(
+                                                image: AssetImage('/images/app_store.png'),
+                                                fit: BoxFit.contain),
+                                          ),
+                                          child: new TextButton(
+                                              onPressed: () async {
+                                                if (await canLaunch(
+                                                    "https://play.google.com/store")) {
+                                                  await launch("https://play.google.com/store");
+                                                } else {
+                                                  throw 'Could not launch null';
+                                                }
+                                              },
+                                              style: ButtonStyle(
+                                                overlayColor: MaterialStateColor.resolveWith(
+                                                    (states) => Colors.transparent),
+                                              ),
+                                              child: null),
+                                        ),
+                                        SizedBox(
+                                          height: 5,
+                                        ),
+                                        Container(
+                                          height: 75,
+                                          width: 200,
+                                          decoration: BoxDecoration(
+                                            image: DecorationImage(
+                                              image: AssetImage('/images/google_store.png'),
+                                            ),
+                                          ),
+                                          child: new TextButton(
+                                              onPressed: () async {
+                                                if (await canLaunch(
+                                                    "https://play.google.com/store")) {
+                                                  await launch("https://play.google.com/store");
+                                                } else {
+                                                  throw 'Could not launch null';
+                                                }
+                                              },
+                                              style: ButtonStyle(
+                                                overlayColor: MaterialStateColor.resolveWith(
+                                                    (states) => Colors.transparent),
+                                              ),
+                                              child: null),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ])
+                              ]),
+                            ),
+                          )
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            )));
+  }
+}


### PR DESCRIPTION
Difference = saifu account is public address + saifu signature functionality. 
It is essentially a explorer account, with fetching blockchain details and then only sign with Saifu opposed to normal way of withdrawing. 

Required step, is to make the front-end user login in (using public address, instead of mnemonics) and retrieve explorer details and display it in "login-in screens".  